### PR TITLE
Add Metro bundler instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ For more detailed instructions, refer to:
 - `COMPREHENSIVE_IOS_BUILD_GUIDE.md` - Complete iOS build guide
 - `BUILD_STATUS_FINAL.md` - Current build status and fixes applied
 
+### Running the development server
+
+Before launching the app, start the Metro bundler:
+
+```bash
+npm start
+# or
+npx expo start
+```
+
+Make sure your iOS simulator or physical device is on the same network as your computer so it can connect to the development server.
+
 ## Environment Configuration
 
 The app uses different environment configurations based on the build profile:


### PR DESCRIPTION
## Summary
- add steps for starting the Metro bundler before launch

## Testing
- `npm run lint` *(fails: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_684516a875708321aa365d2d8400fe55

## Summary by Sourcery

Documentation:
- Add a 'Running the development server' section to README with steps to start the Metro bundler using npm start or npx expo start