### PR TITLE
Fix NetInfo usage

### DIFF
--- a/src/services/networkService.ts
+++ b/src/services/networkService.ts
@@ -1,5 +1,5 @@
-// Using expo's Network utility instead of react-native-community/netinfo
-import * as Network from "expo-network";
+// Network utilities leveraged from @react-native-community/netinfo
+import NetInfo from "@react-native-community/netinfo";
 
 import { ErrorHandler, ErrorType } from "./errorHandler";
 
@@ -9,8 +9,8 @@ class NetworkService {
    * @returns Promise<boolean> - True if connected, false if not
    */
   async isConnected(): Promise<boolean> {
-    const state = await Network.getNetworkStateAsync();
-    return state.isConnected;
+    const state = await NetInfo.fetch();
+    return state.isConnected === true && state.isInternetReachable !== false;
   }
 
   /**
@@ -50,7 +50,7 @@ class NetworkService {
    */
   addNetworkListener(callback: (isConnected: boolean) => void): () => void {
     const unsubscribe = NetInfo.addEventListener((state) => {
-      callback(!!state.isConnected);
+      callback(state.isConnected === true && state.isInternetReachable !== false);
     });
 
     return unsubscribe;


### PR DESCRIPTION
## Summary
- refactor network service to use `@react-native-community/netinfo`

## Testing
- `npx tsc --noEmit` *(fails: File 'expo/tsconfig.base' not found)*
- `npx jest` *(fails to download jest from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68451a4e619c8321b3c158fc0213db88