### PR TITLE
Fix duplicate registerRootComponent call

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,4 +10,3 @@ AppRegistry.registerComponent('main', () => App);
 // It also ensures that whether you load the app in Expo Go or in a native build,
 // the environment is set up appropriately
 registerRootComponent(App);
-registerRootComponent(App);


### PR DESCRIPTION
## Summary
- remove the second `registerRootComponent(App)` call in `index.js`

## Testing
- `node --check index.js`
- `npx jest --version` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68451a502d948321a82d7502a707f55e

## Summary by Sourcery

Bug Fixes:
- Remove the duplicate `registerRootComponent(App)` invocation from the application entry file.