### PR TITLE
Implement lesson navigation

### DIFF
--- a/src/screens/CourseDetailScreen.tsx
+++ b/src/screens/CourseDetailScreen.tsx
@@ -380,10 +380,12 @@ const CourseDetailScreen: React.FC<Props> = ({ route, navigation }) => {
                   ]}
                   onPress={() => {
                     if (activeCourse.progress > 0 || index === 0) {
-                      // TODO: Navigate to lesson screen
-                      console.log("Navigate to lesson:", lesson.id);
+                      navigation.navigate("Lesson", { id: lesson.id });
                     } else {
-                      Alert.alert("Locked", "You need to enroll in this course first.");
+                      Alert.alert(
+                        "Locked",
+                        "You need to enroll in this course first."
+                      );
                     }
                   }}
                 >
@@ -406,9 +408,12 @@ const CourseDetailScreen: React.FC<Props> = ({ route, navigation }) => {
                       <TouchableOpacity
                         onPress={() => {
                           if (activeCourse.progress > 0 || index === 0) {
-                            // TODO: Navigate to lesson
+                            navigation.navigate("Lesson", { id: lesson.id });
                           } else {
-                            Alert.alert("Locked", "You need to enroll in this course first.");
+                            Alert.alert(
+                              "Locked",
+                              "You need to enroll in this course first."
+                            );
                           }
                         }}
                       >


### PR DESCRIPTION
## Summary
- implement navigation logic on CourseDetailScreen when tapping a lesson

## Testing
- `sh scripts/lint.sh` *(fails: 403 Forbidden fetching packages)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68451a51b9908321ab65f09585d2c222