### PR TITLE
Add backend start script and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ npx expo start
 
 Make sure your iOS simulator or physical device is on the same network as your computer so it can connect to the development server.
 
+### Starting the backend server
+
+The project includes a small Node.js backend used for local development. After
+cloning the repo, make the startup script executable and run it:
+
+```bash
+chmod +x start-backend.sh  # first time only
+./start-backend.sh
+```
+
+This launches `server.js` on port `8000` so the app can connect to the mock API.
+
 ## Environment Configuration
 
 The app uses different environment configurations based on the build profile:

--- a/start-backend.sh
+++ b/start-backend.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Launch the Node backend server
+node server.js


### PR DESCRIPTION
## Summary
- implement `start-backend.sh` to run `server.js`
- document how to start the backend in README
- mark `start-backend.sh` as executable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68451d0e2e6c8321867f04e88e9f4d44